### PR TITLE
Responsive resizing bug

### DIFF
--- a/lib/AbsoluteGrid.jsx
+++ b/lib/AbsoluteGrid.jsx
@@ -109,7 +109,7 @@ export default class AbsoluteGrid extends React.Component {
     if(this.state.layoutWidth !== width){
       this.setState({layoutWidth: width});
     }
-
+    this.running = false;
   }
 
 


### PR DESCRIPTION
I think this was mistakenly taken out here:
https://github.com/jrowny/react-absolute-grid/commit/43ab96c7e4552b36032745ace795054b7ef2b829?diff=unified#diff-0e642873a5d3a0a4b6da941a0c719864L112
