### PR TITLE
Set state to default value in BaseDisplayObject

### DIFF
--- a/lib/BaseDisplayObject.jsx
+++ b/lib/BaseDisplayObject.jsx
@@ -3,7 +3,9 @@
 import React from 'react';
 
 export default class BaseDisplayObject extends React.Component {
-
+  
+  state = {};
+  
   updateDrag(x, y) {
     //Pause Animation lets our item return to a snapped position without being animated
     var pauseAnimation = false;


### PR DESCRIPTION
When item is not ever dragged and then filtered out, getStyles tries to read dragX of null and throws, this fixes the problem.
