### PR TITLE
Remove browserify field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,5 @@
     "react-dom": "^0.14.0",
     "webpack": "^1.12.4",
     "webpack-dev-server": "^1.12.1"
-  },
-  "browserify": {
-    "transform": [
-      "babelify"
-    ]
   }
 }


### PR DESCRIPTION
The `browserify` field in package.json breaks our browserify build. We are using babelify with babel 6, which won't parse the babel 5-options in `.babelrc` (`stage`, et. al.).

I dont' think this field is necessary anyway, since the `main` field points to the compiled file in `dist/index.js` already.
