### PR TITLE
Upgraded to babel6 and allowed for server-side rendering

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "stage": 0,
-  "loose": "all",
-  "plugins": ["lodash"]
+  "presets": ["es2015", "react"],
+  "plugins": ["lodash", "babel-plugin-transform-object-rest-spread"]
 }

--- a/lib/AbsoluteGrid.jsx
+++ b/lib/AbsoluteGrid.jsx
@@ -10,16 +10,18 @@ export default class AbsoluteGrid extends React.Component {
 
   constructor(props, context){
     super(props, context);
+    this.getDOMWidth = this.getDOMWidth.bind(this);
+    this.onResize = this.onResize.bind(this);
     this.onResize = debounce(this.onResize, 150);
     this.dragManager = new DragManager(this.props.onMove, this.props.keyProp);
     this.state = {
-      layoutWidth: 0,
+      layoutWidth: 1400,
       dragItemId: 0
     };
   }
 
   render() {
-    if(!this.state.layoutWidth || !this.props.items.length){
+    if(!this.props.items.length){
       return <div ref={node => this.container = node}></div>;
     }
 
@@ -106,7 +108,7 @@ export default class AbsoluteGrid extends React.Component {
     window.removeEventListener('resize', this.onResize);
   }
 
-  onResize = () => {
+  onResize() {
     if (window.requestAnimationFrame) {
       window.requestAnimationFrame(this.getDOMWidth);
     } else {
@@ -114,7 +116,7 @@ export default class AbsoluteGrid extends React.Component {
     }
   }
 
-  getDOMWidth = () => {
+  getDOMWidth() {
     const width = this.container && this.container.clientWidth;
 
     if(this.state.layoutWidth !== width){

--- a/lib/BaseDisplayObject.jsx
+++ b/lib/BaseDisplayObject.jsx
@@ -3,6 +3,11 @@
 import React from 'react';
 
 export default class BaseDisplayObject extends React.Component {
+  constructor(props, context){
+    super(props, context);
+
+    this.onDrag = this.onDrag.bind(this);
+  }
 
   updateDrag(x, y) {
     //Pause Animation lets our item return to a snapped position without being animated
@@ -20,7 +25,7 @@ export default class BaseDisplayObject extends React.Component {
     });
   }
 
-  onDrag = (e) => {
+  onDrag(e) {
     if(this.props.dragManager){
       this.props.dragManager.startDrag(e, this.domNode, this.props.item, this.updateDrag.bind(this));
     }
@@ -43,11 +48,15 @@ export default class BaseDisplayObject extends React.Component {
     return this.props.style;
   }
 
-  componentDidMount() {
-    if (this.props.dragEnabled) {
+  componentWillUpdate(nextProps) {
+    if (nextProps.dragEnabled) {
       this.domNode.addEventListener('mousedown', this.onDrag);
       this.domNode.addEventListener('touchstart', this.onDrag);
       this.domNode.setAttribute('data-key', this.props.id);
+    } else {
+      this.props.dragManager.endDrag();
+      this.domNode.removeEventListener('mousedown', this.onDrag);
+      this.domNode.removeEventListener('touchstart', this.onDrag);
     }
   }
 

--- a/lib/LayoutManager.js
+++ b/lib/LayoutManager.js
@@ -21,7 +21,7 @@ export default class LayoutManager {
     this.zoom = options.zoom;
     this.itemWidth = Math.round(options.itemWidth * this.zoom);
     this.itemHeight = Math.round(options.itemHeight * this.zoom);
-    this.columns = Math.floor(this.layoutWidth / this.itemWidth);
+    this.columns = Math.round(this.layoutWidth / this.itemWidth);
     this.horizontalMargin = (this.columns === 1) ? 0 : Math.round(this.layoutWidth - (this.columns * this.itemWidth)) / (this.columns - 1);
     this.verticalMargin = (options.verticalMargin === -1) ? this.horizontalMargin : options.verticalMargin;
     this.rowHeight = this.itemHeight + this.verticalMargin;
@@ -44,7 +44,6 @@ export default class LayoutManager {
     var row = this.getRow(index);
     var margin = this.horizontalMargin;
     var width = this.itemWidth;
-
     return {
       x: Math.round((col * width) + (col * margin)),
       y: Math.round((this.itemHeight + this.verticalMargin) * row)

--- a/package.json
+++ b/package.json
@@ -19,15 +19,18 @@
     }
   ],
   "license": "MIT",
-  "dependencies": {},
   "peerDependencies": {
     "react": "^0.14.0"
   },
   "devDependencies": {
-    "babel-core": "^5.4.7",
-    "babel-eslint": "^3.1.9",
-    "babel-loader": "^5.1.3",
-    "babel-plugin-lodash": "^0.2.0",
+    "babel-core": "^6.21.0",
+    "babel-eslint": "^7.1.1",
+    "babel-loader": "^6.2.10",
+    "babel-plugin-lodash": "^3.2.11",
+    "babel-plugin-transform-object-rest-spread": "^6.20.2",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-2": "^6.18.0",
     "eslint": "^0.21.2",
     "eslint-plugin-react": "^2.4.0",
     "lodash": "^3.10.1",

--- a/webpack/build.config.js
+++ b/webpack/build.config.js
@@ -9,7 +9,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.jsx?$/, // A regexp to test the require path. accepts either js or jsx
-      loader: 'babel' // The module to load. "babel" is short for "babel-loader"
+      loader: 'babel-loader' // The module to load. "babel" is short for "babel-loader"
     }]
   },
   externals: {


### PR DESCRIPTION
@jrowny @okonet  Hi! I wanted to use your draggable grid, but ran into some syntax issues, babel 6 issues, and server-side rendering issues. So, I upgraded to babel-6, made a few syntax updates, and made some further modifications to allow server-side rendering (i.e. change life-cycle method `componentDidMount` to `componentWillUpdate(nextProps)`) 

Please let me know if we can merge this or if you have any further suggestions. Thank you!